### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Components created using UIShortcut factory are action aware. It means that we c
 win.click('Controller/action', param1, 'param2');
 ```
 
-To define a Controller we need to use CommonJS module. We will pass Como in Contruction function and we will return the public API
+To define a Controller we need to use CommonJS module. We will pass Como in Construction function and we will return the public API
 
 ```js
 // /app/controllers/Test.js


### PR DESCRIPTION
@aaryadewa, I've corrected a typographical error in the documentation of the [como-tabbedwindow](https://github.com/aaryadewa/como-tabbedwindow) project. Specifically, I've changed contruction to construction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
